### PR TITLE
Ignoring build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 /Summer2018-2019/RankMe/RankMe-ejb/target
 /Summer2018-2019/RankMe/RankMe-web/target
 /Summer2018-2019/RankMeClient/target
+*.exe
+*.dll

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,24 @@
 /Summer2018-2019/RankMe/RankMe-ejb/target
 /Summer2018-2019/RankMe/RankMe-web/target
 /Summer2018-2019/RankMeClient/target
+# Exe files
 *.exe
 *.dll
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio 2015
+.vs/


### PR DESCRIPTION
One shouldn't distribute binary files to people ...
For tow reasons:
 - People can build them
  - Some Dlls don't have open source licenses ..